### PR TITLE
Scene Swapping Functionality

### DIFF
--- a/src/components/UI/ColorCycleText.ts
+++ b/src/components/UI/ColorCycleText.ts
@@ -1,0 +1,72 @@
+import Phaser from "phaser";
+import UIText from "./UIText";
+import Text from "~/interfaces/UI/Text/Text";
+import VectorPos from "~/interfaces/universal/VectorPos";
+import ColorAnimation from "~/interfaces/animations/ColorAnimation";
+import Animation from "~/interfaces/animations/Animation";
+
+// Unlike most other UI components, ColorCycleText maintains a copy of its
+// in-scene creation. This allows for ColorCycleText to update itself without
+// relying on a reference to be kept explicitly in the scene.
+// This functionality isn't needed for "static" components.
+export default class ColorCycleText extends UIText implements ColorAnimation, Animation {
+    sceneObject: Phaser.GameObjects.Text | null | undefined;
+    
+    colors: Phaser.Display.Color[] = [];
+    speed: number;
+    repeat: boolean;
+    bounce: boolean;
+
+    startIteration: number = 0;
+    endIteration: number = 1;
+    time: number = 0;
+
+    constructor(properties: Text, colors: string[], speed: number, animation: Animation) {
+        super(properties);
+        for (let i = 0; i < colors.length; i++) {
+            this.colors.push(Phaser.Display.Color.HexStringToColor(colors[i]));
+        }
+
+        this.speed = speed;
+        this.repeat = animation.repeat;
+        this.bounce = animation.bounce;
+    }
+
+    // Add the text to the screen
+    add(position: VectorPos, scene: Phaser.Scene) {
+        if (this.sceneObject != null) {
+            console.warn("AnimatedText can only be added to the scene once.");
+        }
+        this.sceneObject = (scene.add.text(position.x + this.offset.x, position.y + this.offset.y, this.text, this.normalStyle)).setOrigin(this.origin.x, this.origin.y);
+        return this.sceneObject;
+    }
+
+    update(delta: number) {
+        if (this.sceneObject == null) {
+            console.warn("ColorCycleText must be added to the scene before updating.");
+            return;
+        }
+        else if (this.colors.length <=  1) {
+            console.warn("ColorCycleText must have at least two colors.");
+            return;
+        }
+        let r = (this.colors[this.endIteration].red - this.colors[this.startIteration].red) * this.time + this.colors[this.startIteration].red;
+        let g = (this.colors[this.endIteration].green - this.colors[this.startIteration].green) * this.time + this.colors[this.startIteration].green;
+        let b = (this.colors[this.endIteration].blue - this.colors[this.startIteration].blue) * this.time + this.colors[this.startIteration].blue;
+
+        // r = 
+
+        let newColor = new Phaser.Display.Color(r, g, b);
+
+        this.sceneObject.setColor(newColor.rgba);
+        this.time += this.speed * delta / 1000.0;
+        if (this.time > 1) {
+            this.time = 0;
+            this.startIteration = this.endIteration;
+            this.endIteration++;
+            if (this.endIteration >= this.colors.length) {
+                this.endIteration = 0;
+            }
+        }
+    }
+}

--- a/src/interactions/UIInteractions.ts
+++ b/src/interactions/UIInteractions.ts
@@ -19,6 +19,6 @@ export function TitleClick(container: ButtonText, text: Phaser.GameObjects.Text)
 }
 
 // Changes the scene to the game
-export function GoToGame() {
-    alert("go to game!");
+export function GoToScene(scene: Phaser.Scenes.ScenePlugin, sceneName: string | Phaser.Scene) {
+    scene.start(sceneName);
 }

--- a/src/interfaces/animations/Animation.ts
+++ b/src/interfaces/animations/Animation.ts
@@ -1,0 +1,4 @@
+export default interface Animation {
+    repeat: boolean;
+    bounce: boolean;
+}

--- a/src/interfaces/animations/ColorAnimation.ts
+++ b/src/interfaces/animations/ColorAnimation.ts
@@ -1,0 +1,4 @@
+export default interface ColorAnimation {
+    colors: Phaser.Display.Color[]
+    speed: number;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import Phaser from "phaser";
 
 // Scenes
 import StartMenu from "./scenes/StartMenu";
+import OfflineGame from "./scenes/OfflineGame";
 
 const config: Phaser.Types.Core.GameConfig = {
     type: Phaser.AUTO,
@@ -12,7 +13,7 @@ const config: Phaser.Types.Core.GameConfig = {
     },
     physics: {
     },
-    scene: [StartMenu],
+    scene: [StartMenu, OfflineGame],
     parent: "game"
 }
 

--- a/src/scenes/OfflineGame.ts
+++ b/src/scenes/OfflineGame.ts
@@ -1,0 +1,21 @@
+import Phaser from "phaser";
+
+export default class OfflineGame extends Phaser.Scene {
+
+    constructor() {
+        super("OfflineGame");
+    }
+
+    preload() {
+
+    }
+
+    create() {
+        this.add.text(200, 200, "hello");
+    }
+
+    update() {
+
+    }
+
+}

--- a/src/scenes/StartMenu.ts
+++ b/src/scenes/StartMenu.ts
@@ -9,12 +9,13 @@ import {
     settingsButtonText, settingsButtonImage, titleTextStyleA, titleTextStyleB, titleTextStyleC
 } from "../constants/StartMenuUI";
 import { GoToGame, TitleClick } from "../interactions/UIInteractions";
+import ColorCycleText from "../components/UI/ColorCycleText";
 
 export default class StartMenu extends Phaser.Scene {
     playButton: Button | undefined;
     statsButton: Button | undefined;
     settingsButton: Button | undefined;
-    titleText: Button | undefined;
+    titleText: ColorCycleText | undefined;
     
     constructor() {
         super("StartMenu");
@@ -46,7 +47,27 @@ export default class StartMenu extends Phaser.Scene {
 
 
         // Title Text
-        this.titleText = new Button({ x: this.scale.width/2, y: 150 }, new ButtonText({
+        this.titleText = new ColorCycleText({
+            text: "oypu!",
+            normalStyle: titleTextStyleA,
+            hoverStyle: titleTextStyleB,
+            clickedStyle: titleTextStyleC,
+            origin: { x: 0.5, y: 0.5 },
+            offset: { x: this.scale.width/2, y: 150 },
+        },
+            ["#ffffff",
+            "#ffaa00",
+            "#ffee00", 
+            "#4466ff", 
+            "#bb11ef"],
+            0.5,
+        {
+            repeat: true,
+            bounce: true
+        });
+        this.titleText.add({x: 0, y: 0}, this);
+        //this.titleText
+        /*this.titleText = new Button({ x: this.scale.width/2, y: 150 }, new ButtonText({
             text: "oypu!",
             normalStyle: titleTextStyleA,
             hoverStyle: titleTextStyleB,
@@ -55,10 +76,10 @@ export default class StartMenu extends Phaser.Scene {
             offset: undefined,
         }, TitleClick));
 
-        this.titleText.add(Phaser.Math.Vector2.ZERO, this);
+        this.titleText.add(Phaser.Math.Vector2.ZERO, this);*/
     }
 
-    update() {
-
+    update(time: number, delta: number) {
+        this.titleText.update(delta);
     }
 }

--- a/src/scenes/StartMenu.ts
+++ b/src/scenes/StartMenu.ts
@@ -8,7 +8,7 @@ import {
     playButtonText, playButtonImage, statsButtonText, statsButtonImage,
     settingsButtonText, settingsButtonImage, titleTextStyleA, titleTextStyleB, titleTextStyleC
 } from "../constants/StartMenuUI";
-import { GoToGame, TitleClick } from "../interactions/UIInteractions";
+import { GoToScene, TitleClick } from "../interactions/UIInteractions";
 import ColorCycleText from "../components/UI/ColorCycleText";
 
 export default class StartMenu extends Phaser.Scene {
@@ -32,19 +32,14 @@ export default class StartMenu extends Phaser.Scene {
     }
 
     create() {
-        // Title
-        
-
         // Menu Buttons
-        this.playButton = new Button({ x: this.scale.width / 2 - 64, y: 400 }, new ButtonText(playButtonText, GoToGame), playButtonImage);
-        this.statsButton = new Button({ x: this.scale.width / 2 - 62, y: 525 }, new ButtonText(statsButtonText, GoToGame), statsButtonImage);
-        this.settingsButton = new Button({ x: this.scale.width / 2 - 64, y: 650 }, new ButtonText(settingsButtonText, GoToGame), settingsButtonImage);
+        this.playButton = new Button({ x: this.scale.width / 2 - 64, y: 400 }, new ButtonText(playButtonText, () => { GoToScene(this.scene, "OfflineGame"); }), playButtonImage);
+        this.statsButton = new Button({ x: this.scale.width / 2 - 62, y: 525 }, new ButtonText(statsButtonText, () => { GoToScene(this.scene, "StartMenu"); }), statsButtonImage);
+        this.settingsButton = new Button({ x: this.scale.width / 2 - 64, y: 650 }, new ButtonText(settingsButtonText, () => { GoToScene(this.scene, "StartMenu"); }), settingsButtonImage);
 
         this.playButton.add(Phaser.Math.Vector2.ZERO, this);
         this.statsButton.add(Phaser.Math.Vector2.ZERO, this);
         this.settingsButton.add(Phaser.Math.Vector2.ZERO, this);
-
-
 
         // Title Text
         this.titleText = new ColorCycleText({
@@ -66,20 +61,9 @@ export default class StartMenu extends Phaser.Scene {
             bounce: true
         });
         this.titleText.add({x: 0, y: 0}, this);
-        //this.titleText
-        /*this.titleText = new Button({ x: this.scale.width/2, y: 150 }, new ButtonText({
-            text: "oypu!",
-            normalStyle: titleTextStyleA,
-            hoverStyle: titleTextStyleB,
-            clickedStyle: titleTextStyleC,
-            origin: { x: 0.5, y: 0.5 },
-            offset: undefined,
-        }, TitleClick));
-
-        this.titleText.add(Phaser.Math.Vector2.ZERO, this);*/
     }
 
     update(time: number, delta: number) {
-        this.titleText.update(delta);
+        this.titleText?.update(delta);
     }
 }


### PR DESCRIPTION
This pull request allows for the scene to be swapped by calling the "GoToScene()" function from UIInteractions. GoToScene requires two parameters

**GoToScene(scene: Phaser.Scenes.ScenePlugin, sceneName: string | Phaser.Scene)**
 - scene: The phaser scene object, should be passed from the currently active scene
 - sceneName: The name of the scene to transition to. This scene must be specified in the phaser config in main.ts

Additionally, there is another extension for Text, color cycling! It's not fully complete, but will serve as a simple way to test animations in the game. Currently, this is being used on the start menu.